### PR TITLE
[# 115660011] As a developer integrating heroic-sns's auto-confirmation into a legacy SNS subscriber, make rewinding the input for each request an option to the Heroic::SNS::Endpoint middleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ POST to the controller action. Be careful not to disable it for more
 actions than you need. Be sure to disable any authentication checks for
 that action, too.
 
+### :pass_thru
+
+`:pass_thru` affects whether further middleware (or your application) see the
+message as parameters. When this is `false` (the default), the message is only
+available as the value of `env['sns.message']`.
+
+If `true`, the body is left alone; if you already have a parser for your SNS
+messages but want this Gem's security (and autoconfirmation) features, setting
+the value to true can be handy.
+
+However, the application should still process `env['sns.error']` if present.
+
 ## Multiple endpoint URLs
 
 If you are receiving multiple notifications at multiple endpoint URLs,

--- a/lib/heroic/sns/endpoint.rb
+++ b/lib/heroic/sns/endpoint.rb
@@ -41,6 +41,15 @@ module Heroic
   - If nil, there is no special handling and the message is passed along to your
     app.
 
+  +:pass_thru+ determines if the body of the request will be changed.
+  - If false (the default), the message contents will only be available in
+    +env['sns.message']+ and removed from further processing by Rack.
+  - If true, in addition to setting the +env['sns.message']+, the original posted
+    contents will remain in the Rack request. This can be useful for adding
+    this Gem into a legacy SNS application quickly.
+  - Your application should still look for a value in +env['sns.error']+ for any
+    other issues.
+
   You can install this in your config.ru:
     use Heroic::SNS::Endpoint, :topics => /whatever/
 
@@ -58,6 +67,7 @@ module Heroic
         options = DEFAULT_OPTIONS.merge(opt)
         @auto_confirm = options[:auto_confirm]
         @auto_resubscribe = options[:auto_resubscribe]
+        @pass_thru = options[:pass_thru]
         if 1 < [:topic, :topics].count { |k| options.has_key?(k) }
           raise ArgumentError.new("supply zero or one of :topic, :topics")
         end
@@ -110,6 +120,7 @@ module Heroic
       def call_on_topic(env)
         begin
           message = Message.new(env['rack.input'].read)
+          env['rack.input'].rewind if @pass_thru
           check_headers!(message, env)
           message.verify!
           case message.type

--- a/lib/heroic/sns/version.rb
+++ b/lib/heroic/sns/version.rb
@@ -1,5 +1,5 @@
 module Heroic
   module SNS
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -44,4 +44,16 @@ class EndpointTest < Test::Unit::TestCase
     assert_nothing_raised { app.call(@env) }
   end
 
+  def test_pass_thru
+    result = [0, {}, []]
+
+    test = Proc.new do |env|
+      msg_json = JSON.parse(env['rack.input'].read)
+      assert_equal(msg_json['Message'],'booyakasha!')
+      result
+    end
+    sns('notification')
+    app = Heroic::SNS::Endpoint.new test, :topic => @msg.topic_arn, :pass_thru => true
+    assert_equal result, app.call(@env)
+  end
 end


### PR DESCRIPTION
[Tracker #115660011](https://www.pivotaltracker.com/story/show/115660011)

This merge gets our fork up to the place where it'll be if the maintainer of the Gem accepts my PR.  The other PRs associated with this test that the changes all work; they should _not_ be merged until this one is, because their Gemfiles will need to be modified to reflect this merge being available in master.

See:
- [https://github.com/ConsultingMD/heroic-sns/pull/2] 
- [https://github.com/ConsultingMD/service/pull/53]
- [https://github.com/ConsultingMD/frick/pull/260]
- [https://github.com/ConsultingMD/ConsultingMD/pull/5133]
- [https://github.com/ConsultingMD/stone/pull/58]

The branch that is going toward the upstream is contribute/pass_thru_option ; this branch only differs from that because we had our quick hack in our `master`.
